### PR TITLE
Split out CI and Linting into their own workflows

### DIFF
--- a/.github/config/rubocop_linter_action.yml
+++ b/.github/config/rubocop_linter_action.yml
@@ -1,5 +1,4 @@
 # See https://rubocop-linter-action.readthedocs.io/en/v3.0.0/configuration/ for more details
-check_name: 'Rubocop'
 versions:
   - rubocop
   - rubocop-minitest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: Tests
 
 on:
   pull_request:
@@ -9,21 +9,22 @@ on:
       - master
 
 jobs:
-  build:
+  test:
+    name: Tests Action
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
     - uses: actions/checkout@v2
-    - name: Cache Ruby Gems
-      uses: actions/cache@v1
+    - name: Set up Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - uses: actions/cache@v1.1.2
       with:
         path: vendor/bundle
         key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-gem-
-    - name: Set up Ruby
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.6
     - name: Install Dependencies
       run: |
         gem install bundler --no-document
@@ -31,7 +32,3 @@ jobs:
         bundle install --jobs 4 --local
     - name: Run tests
       run: script/test
-    #- name: Rubocop Linter Action
-    #  uses: andrewmcodes/rubocop-linter-action@v3.1.0
-    #  env:
-    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,45 @@
+
+name: Linters
+
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - master
+
+jobs:
+  rubocop:
+    name: RuboCop Action
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7.x
+      - uses: actions/cache@v1.1.2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gem-
+      - name: Bundle
+        run: |
+          gem install bundler
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Run Rubocop
+        uses: andrewmcodes/rubocop-linter-action@v3.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  shell_linter:
+    name: Shell Lint Action
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    steps:
+      - uses: actions/checkout@master
+      - name: Run Shell Linter
+        uses: azohra/shell-linter@v0.1.0

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -16,30 +16,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.7.x
-      - uses: actions/cache@v1.1.2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gem-
-      - name: Bundle
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
       - name: Run Rubocop
         uses: andrewmcodes/rubocop-linter-action@v3.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  shell_linter:
-    name: Shell Lint Action
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    steps:
-      - uses: actions/checkout@master
-      - name: Run Shell Linter
-        uses: azohra/shell-linter@v0.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,8 +32,3 @@ jobs:
         bundle install --jobs 4 --local
     - name: Run tests
       run: script/test
-    - name: Coveralls
-      uses: coverallsapp/github-action@v1.0.1
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: coverage/.resultset.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,3 +32,8 @@ jobs:
         bundle install --jobs 4 --local
     - name: Run tests
       run: script/test
+    - name: Coveralls
+      uses: coverallsapp/github-action@v1.0.1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: coverage/.resultset.json

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
   DisplayStyleGuide: true
   ExtraDetails: true
   Exclude:
+    - 'vendor/**/*'
     - 'env.rb'
 
 Metrics/MethodLength:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Micropub to GitHub Pages
 
-![Build Status](https://github.com/lildude/micropub-github-pages/workflows/Continuous%20Integration/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/lildude/micropub-github-pages/badge.svg)](https://coveralls.io/github/lildude/micropub-github-pages)
+![](https://github.com/lildude/micropub-github-pages/workflows/Tests/badge.svg) ![](https://github.com/lildude/micropub-github-pages/workflows/Linters/badge.svg) [![Coverage Status](https://coveralls.io/repos/github/lildude/micropub-github-pages/badge.svg)](https://coveralls.io/github/lildude/micropub-github-pages)
 
 A simple Micropub server that accepts [Micropub](http://micropub.net/) requests and creates and publishes a Jekyll/GitHub Pages post to a configured GitHub repository.  This project is inspired by [Micropub to GitHub](https://github.com/voxpelli/webpage-micropub-to-github), a Node.js implementation.
 


### PR DESCRIPTION
Keeps things separate for easy maintenance and monitoring as Rubocop issues shouldn't block tests.