### PR TITLE
Ensure Coveralls coverage is updated

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,4 +31,6 @@ jobs:
         bundle config path vendor/bundle
         bundle install --jobs 4 --local
     - name: Run tests
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: script/test


### PR DESCRIPTION
Seems I've forgotten something somewhere WRT getting the coverage updated on coveralls.io.

I'm pretty sure I don't need the whole action and in fact don't want it as I don't want the comment noise.