### PR TITLE
Add support for multiple destinations extension

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require 'rubocop/rake_task'
 task default: 'test'
 
 Rake::TestTask.new do |t|
-  ENV['SITES_CONFIG'] = '{"sites":{"testsite":{"github_repo":"lildude/micropub-github-pages","permalink_style":"/:categories/:year/:month/:title","site_url":"https://example.com","full_image_urls":false,"image_dir":"img"}},"micropub":{"token_endpoint":"http://example.com/micropub/token"},"download_photos":true,"syndicate_to":{"0":{"uid":"https://twitter.com/lildude","name":"Twitter","silo_pub_token":"0987654321"},"1":{"uid":"https://example.com/foobar","name":"fooBar"}}}'
+  ENV['SITES_CONFIG'] = '{"sites":{"testsite":{"name": "Test Site","github_repo":"lildude/micropub-github-pages","permalink_style":"/:categories/:year/:month/:title","site_url":"https://example.com","full_image_urls":false,"image_dir":"img"}},"micropub":{"token_endpoint":"http://example.com/micropub/token"},"download_photos":true,"syndicate_to":{"0":{"uid":"https://twitter.com/lildude","name":"Twitter","silo_pub_token":"0987654321"},"1":{"uid":"https://example.com/foobar","name":"fooBar"}}}'
   t.test_files = FileList['test/*_test.rb']
   t.warning = false
 end

--- a/app.rb
+++ b/app.rb
@@ -429,7 +429,7 @@ get '/micropub' do
     config = {}
     config["destination"] = []
     settings.sites.each do |site, opts|
-      config["destination"] << { uid: "#{request.base_url}/micropub/#{site}", name: opts['name'] || site }
+      config["destination"] << { uid: opts['site_url'], name: site }
     end
     body JSON.generate(config)
   else

--- a/app.rb
+++ b/app.rb
@@ -463,6 +463,13 @@ get '/micropub/:site' do |site|
   end
 end
 
+# Multisite publishing - assumes mp-destination=site_section_name as per the config.yml
+post '/micropub' do
+  halt 404 unless params.include? 'mp-destination'
+  site = params.delete('mp-destination')
+  call! env.merge("PATH_INFO" => "/micropub/#{site}")
+end
+
 post '/micropub/:site' do |site|
   halt 404 unless settings.sites.include? site
 

--- a/test/form_encoded_test.rb
+++ b/test/form_encoded_test.rb
@@ -29,6 +29,20 @@ class FormEncodedTest < Minitest::Test
     assert last_response.not_found?
   end
 
+  def test_get_config_for_all_sites
+    stub_token
+    get '/micropub?q=config', nil, 'HTTP_AUTHORIZATION' => 'Bearer 1234567890'
+    assert last_response.ok?
+    parse_body = JSON.parse(last_response.body)
+    assert_equal parse_body['destination'].count, 1
+    assert_equal parse_body['destination'][0]['name'], 'Test Site'
+    assert_equal parse_body['destination'][0]['uid'], 'http://example.org/micropub/testsite'
+
+    get '/micropub?q=source', nil, 'HTTP_AUTHORIZATION' => 'Bearer 1234567890'
+    refute last_response.ok?
+    assert last_response.body.include? 'invalid_request'
+  end
+
   def test_get_config_with_authorisation_header
     stub_token
     get '/micropub/testsite?q=config', nil, 'HTTP_AUTHORIZATION' => 'Bearer 1234567890'

--- a/test/form_encoded_test.rb
+++ b/test/form_encoded_test.rb
@@ -35,8 +35,8 @@ class FormEncodedTest < Minitest::Test
     assert last_response.ok?
     parse_body = JSON.parse(last_response.body)
     assert_equal parse_body['destination'].count, 1
-    assert_equal parse_body['destination'][0]['name'], 'Test Site'
-    assert_equal parse_body['destination'][0]['uid'], 'http://example.org/micropub/testsite'
+    assert_equal parse_body['destination'][0]['name'], 'testsite'
+    assert_equal parse_body['destination'][0]['uid'], 'https://example.com'
 
     get '/micropub?q=source', nil, 'HTTP_AUTHORIZATION' => 'Bearer 1234567890'
     refute last_response.ok?

--- a/test/form_encoded_test.rb
+++ b/test/form_encoded_test.rb
@@ -228,6 +228,27 @@ class FormEncodedTest < Minitest::Test
     assert_equal "https://example.com/#{now.strftime('%Y')}/#{now.strftime('%m')}/this-is-a-post", last_response.header['Location']
   end
 
+  # TODO: Not sure this works yet.
+  def test_new_entry_with_mp_destination
+    stub_token
+    stub_get_github_request
+    stub_get_pages_branch
+    stub_post_github_request
+    stub_patch_github_request
+    now = Time.now
+    post('/micropub', {
+           'mp-destination' => 'testsite',
+           :h => 'entry',
+           :name => 'This is a 😍 Post!!',
+           :content => 'This is the content',
+           :category => %w[tag1 tag2],
+           'syndicate-to' => 'https://myfavoritesocialnetwork.example/lildude'
+         }, 'HTTP_AUTHORIZATION' => 'Bearer 1234567890')
+    assert last_response.created?, "Expected 201 but got #{last_response.status}"
+    assert last_response.header.include?('Location'), "Expected 'Location' header, but got #{last_response.header}"
+    assert_equal "https://example.com/#{now.strftime('%Y')}/#{now.strftime('%m')}/this-is-a-post", last_response.header['Location']
+  end
+
   def test_new_note_with_title_in_markdown_content_becomes_article
     stub_token
     stub_get_github_request


### PR DESCRIPTION
Add support for the proposed `destination` extension from https://indieweb.org/Micropub-extensions#Destination

I don't think any client support this yet, but I really hope to find one as it's a PITA having to re-auth to switch between my blogs.