### PR TITLE
Add support for querying post-types

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -61,6 +61,7 @@ get '/micropub' do
     settings.sites.each do |site, opts|
       config['destination'] << { uid: site, name: opts['site_url'] }
     end
+    config['post-types'] = post_types
     body JSON.generate(config)
   else
     error('invalid_request')

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -73,6 +73,15 @@ module AppHelpers
     content if ENV['RACK_ENV'] == 'test'
   end
 
+  # Return the list of supported post types. Add entries here as new templates are added.
+  def post_types
+    [
+      { type: 'note', name: 'Note', properties: %w[content category] },
+      { type: 'article', name: 'Article', properties: %w[name content category] },
+      { type: 'photo', name: 'Photo', properties: %w[content category] }
+    ]
+  end
+
   # Files should be an array of path and base64 encoded content
   def commit_to_github(files, type)
     # Verify the repo exists

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -21,6 +21,7 @@ class Query < Minitest::Test
     assert_equal parse_body['destination'].count, 1
     assert_equal parse_body['destination'][0]['uid'], 'testsite'
     assert_equal parse_body['destination'][0]['name'], 'https://example.com'
+    assert_equal parse_body['post-types'].count, 3
 
     get '/micropub?q=source'
     refute last_response.ok?


### PR DESCRIPTION
Add support for querying post-types as per https://github.com/indieweb/micropub-extensions/issues/33

This only returns post types for which I'm created templates.