### PR TITLE
Simplify token endpoint config option

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,8 @@
 
 require 'rake/testtask'
 require 'rubocop/rake_task'
+require 'yaml'
+require 'json'
 
 task default: 'test'
 
@@ -18,4 +20,9 @@ desc 'run irb console'
 task :console, :environment do |_, args|
   ENV['RACK_ENV'] = args[:environment] || 'development'
   exec 'pry -r ./app.rb -e "App = Sinatra::Application.new"'
+end
+
+desc 'print config.yml as json'
+task :jsoncfg do
+  puts YAML.load_file('config.yml').to_json
 end

--- a/config-example.yml
+++ b/config-example.yml
@@ -8,6 +8,4 @@ sites:
 
 download_photos: true # Ensure linked images are added to repo
 
-micropub:
-  token_endpoint:
-  token_me:
+micropub_token_endpoint:

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -25,7 +25,7 @@ module AppHelpers
   def verify_token
     return %w[create update delete undelete media] if ENV['RACK_ENV'] == 'development'
 
-    resp = HTTParty.get(Sinatra::Application.settings.micropub[:token_endpoint], {
+    resp = HTTParty.get(Sinatra::Application.settings.micropub_token_endpoint, {
                           headers: {
                             'Accept' => 'application/x-www-form-urlencoded',
                             'Authorization' => "Bearer #{@access_token}"

--- a/test/fixtures/config.yml
+++ b/test/fixtures/config.yml
@@ -6,8 +6,7 @@ sites:
     full_image_urls: false # Include site_url in img paths
     image_dir: "img"
 
-micropub:
-  token_endpoint: "http://example.com/micropub/token"
+micropub_token_endpoint: "http://example.com/micropub/token"
 
 download_photos: true
 


### PR DESCRIPTION
We only need the token endpoint now `me` is optional.

Also added a task to print the `config.yml` as JSON