### PR TITLE
Improve CI and Linter actions

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -3,17 +3,18 @@ name: Linters
 
 on:
   pull_request:
-    branches:
-      - "*"
+    paths-ignore:
+      - '**.md'
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
 
 jobs:
   rubocop:
     name: RuboCop Action
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
       - uses: actions/checkout@v2
       - name: Run Rubocop

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,20 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.x
-    - uses: actions/cache@v1.1.2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gem-
-    - name: Install Dependencies
-      run: |
-        gem install bundler --no-document
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --local
+        ruby-version: 2.7
+        bundler-cache: true
     - name: Run tests
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,6 @@ jobs:
   test:
     name: Tests Action
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,11 +2,13 @@ name: Tests
 
 on:
   pull_request:
-    branches:
-      - '*'
+    paths-ignore:
+      - '**.md'
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
 
 jobs:
   test:


### PR DESCRIPTION
There's no need to run CI or the linter if we've only made doc changes, so lets not. There's also no need to try and catch "ci skip" commit messages as actions handle this themselves now.

Lets also use the ruby/setup-ruby workflow as it is way more efficient than the actions/setup-ruby workflow.